### PR TITLE
Fix raster grid method

### DIFF
--- a/pygus/gus/models.py
+++ b/pygus/gus/models.py
@@ -228,7 +228,7 @@ class Urban(Model):
             self.time_horizon = experiment["time_horizon"]
         else:
             logging.warning(
-                "Now time horizon found, the model will have to be run for a fixed number of years."
+                "No time horizon found, the model will have to be run for a fixed number of years."
             )
 
     def _handle_site_configuration(self, site_config: SiteConfig, population_size: int):


### PR DESCRIPTION
@oguzhan I used python's `time` library to check your slow conversion function:

```
    logger.info("Converting lat lng to xy...takes a while...")

    start = time.time()
    tree_df = latlng_array_to_xy(tree_df, "lat", "lng")
    end = time.time()
    logger.warning(f"latlng_array_to_xy took {end - start} seconds")

    minx = min(tree_df.xpos)
    miny = min(tree_df.ypos)

    start = time.time()
    tree_df = tree_df.apply(lambda row: raster_grid(row, minx, miny, 100), axis=1)
    end = time.time()
    logger.warning(f"raster grid took {end - start} seconds")
```

and it turned out the `raster_grid` function was the main culprit
```
latlng_array_to_xy took 0.007266044616699219 seconds
raster grid took 25.704536199569702 seconds
```

Once, I apply this function to the Dataframe as a whole (instead of row by row):

```
    tree_df["gus_x"] = ((tree_df["xpos"] - minx) // 100).astype(int)
    tree_df["gus_y"] = ((tree_df["ypos"] - miny) // 100).astype(int)
```

we get

```
latlng_array_to_xy took 0.0064449310302734375 seconds
raster grid took 0.002843141555786133 seconds
```

:D